### PR TITLE
Screen marking misinterpretation fix

### DIFF
--- a/hardware.html
+++ b/hardware.html
@@ -86,7 +86,7 @@
                         4:3 aspect ratio<br>
                         IPS<br>
                         st7789v controller<br>
-                        AN2801 V1 24Pin connector<br>
+                        RN2801 V1 24Pin connector<br>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
AN2801 was my earlier misinterpretation; the new clear shot at https://discord.com/channels/741895796315914271/1092831839955193987/1234175646184247397 in https://discord.gg/retrohandhelds shows RN2801 instead